### PR TITLE
Srcporter fix policy

### DIFF
--- a/playbooks/roles/demo/templates/openshift_policy_fix/policy.json.j2
+++ b/playbooks/roles/demo/templates/openshift_policy_fix/policy.json.j2
@@ -6,7 +6,6 @@
     "remediation": {{ item.json.remediation | tojson }},
     "disabled": {{ item.json.disabled | lower }},
     "categories": {{ item.json.categories | tojson }},
-    "fields": {{ item.json.fields | tojson }},
     "lifecycleStages": {{ item.json.lifecycleStages | tojson }},
     "whitelists": {{ item.json.whitelists | tojson  }},
     "exclusions": [

--- a/playbooks/roles/demo/templates/openshift_policy_fix/policy.json.j2
+++ b/playbooks/roles/demo/templates/openshift_policy_fix/policy.json.j2
@@ -7,7 +7,6 @@
     "disabled": {{ item.json.disabled | lower }},
     "categories": {{ item.json.categories | tojson }},
     "lifecycleStages": {{ item.json.lifecycleStages | tojson }},
-    "whitelists": {{ item.json.whitelists | tojson  }},
     "exclusions": [
         {% for exclusion in item.json.exclusions %}{{ exclusion | tojson }},{% endfor %}
         {% for namespace in item.item.namespaces %}


### PR DESCRIPTION
Removing the "fields" and "whitelists" attribute that were deprecated in ACS 3.70